### PR TITLE
First-class Alias Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 nosedrum-*.tar
 
+.vscode/

--- a/lib/nosedrum/command.ex
+++ b/lib/nosedrum/command.ex
@@ -129,5 +129,13 @@ defmodule Nosedrum.Command do
   """
   @callback command(msg :: Message.t(), args :: [String.t()] | any()) :: any()
 
-  @optional_callbacks [parse_args: 1]
+  @doc """
+  An optional callback that returns a list of aliases for the command.
+
+  If any of the aliases returned conflict with existing commands/aliases, they
+  will be overwritten.
+  """
+  @callback aliases() :: [String.t()]
+
+  @optional_callbacks [parse_args: 1, aliases: 0]
 end

--- a/lib/nosedrum/command.ex
+++ b/lib/nosedrum/command.ex
@@ -132,8 +132,9 @@ defmodule Nosedrum.Command do
   @doc """
   An optional callback that returns a list of aliases for the command.
 
-  If any of the aliases returned conflict with existing commands/aliases, they
-  will be overwritten.
+  `Nosedrum.Storage` implementations use this function when adding/removing a command
+  with `add_command/2` or `remove_command/2`. If any of the aliases returned conflict
+  with existing commands/aliases, they will be overwritten.
   """
   @callback aliases() :: [String.t()]
 

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -47,7 +47,9 @@ defmodule Nosedrum.Storage do
   @doc """
   Add a new command under the given `path`.
 
-  If the command already exists, no error should be returned.
+  If a command has the c:Nosedrum.Command.aliases/0 callback defined,
+  they will also be added under `path`. If the command already exists,
+  no error should be returned.
   """
   @callback add_command(path :: command_path, command :: Module.t(), storage :: reference) ::
               :ok | {:error, String.t()}
@@ -55,7 +57,9 @@ defmodule Nosedrum.Storage do
   @doc """
   Remove the command under the given `path`.
 
-  If the command does not exist, no error should be returned.
+  If a command has the c:Nosedrum.Command.aliases/0 callback defined,
+  they will also be removed under `path`. If the command does not exist,
+  no error should be returned.
   """
   @callback remove_command(path :: command_path, storage :: reference) ::
               :ok | {:error, String.t()}


### PR DESCRIPTION
Close #1 

At the moment, the `Storage` behaviour is untouched, which means users who implement their own `Storage` can choose whether they want to do anything with an `aliases` callback in their commands.

I know `if`s aren't the go-to for conditionals in Elixir, so if you know of a more functional approach (or feedback in general), please lmk ;D

Also, a bit unrelated, but about half of the unit tests aren't run with `mix test` because of errors like this:
```elixir
???????

  7) Nosedrum.Converters.ChannelTest: failure on setup_all callback, all tests have been invalidated
     ** (RuntimeError) failed to start child with the spec Nostrum.Cache.CacheSupervisor.
     Reason: already started: #PID<0.246.0>
     stacktrace:
       (ex_unit 1.12.1) lib/ex_unit/callbacks.ex:433: ExUnit.Callbacks.start_supervised!/2
       test/nosedrum/converters/channel_test.exs:12: Nosedrum.Converters.ChannelTest.__ex_unit_setup_all_0/1
       test/nosedrum/converters/channel_test.exs:1: Nosedrum.Converters.ChannelTest.__ex_unit__/2
```
I imagine Nostrum capped how many `Nostrum.Cache.CacheSupervisor`s can be spawned since the tests were written?