### PR TITLE
Application/Slash command support

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -6,19 +6,6 @@ defmodule Nosedrum.ApplicationCommand do
   Like regular commands, application command modules are stateless on their own.
   """
 
-  @option_type_map %{
-    sub_command: 1,
-    sub_command_group: 2,
-    string: 3,
-    integer: 4,
-    boolean: 5,
-    user: 6,
-    channel: 7,
-    role: 8,
-    mentionable: 9,
-    number: 10,
-  }
-
   @type response_type :: :channel_message_with_source | :deferred_channel_message_with_source |
   :deferred_update_message | :pong | :update_message
 

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -1,0 +1,154 @@
+defmodule Nosedrum.ApplicationCommand do
+  @moduledoc """
+  The application command behaviour specifies the interface that a slash, user,
+  or message command module should implement.
+
+  Like regular commands, application command modules are stateless on their own.
+  """
+
+  @option_type_map %{
+    sub_command: 1,
+    sub_command_group: 2,
+    string: 3,
+    integer: 4,
+    boolean: 5,
+    user: 6,
+    channel: 7,
+    role: 8,
+    mentionable: 9,
+    number: 10,
+  }
+
+  @type response_type :: :channel_message_with_source | :deferred_channel_message_with_source |
+  :deferred_update_message | :pong | :update_message
+
+  @typedoc """
+  `:allowed_mentions` should contain "users", "roles", and/or "everyone", or be an empty list.
+  """
+  @type response_field ::
+          {:type, response_type}
+          | {:content, String.t()}
+          | {:embeds, [Embed.t()]}
+          | {:components, [map()]}
+          | {:ephemeral?, boolean()}
+          | {:tts?, boolean()}
+          | {:allowed_mentions, [String.t()] | []}
+
+  @typedoc """
+  A Keyword list of fields to include in the interaction response.
+
+  If `:type` is not specified, it will default to `:channel_message_with_source`, though one of
+  either `:embeds` or `:content` must be present.
+
+  ## Example
+
+    def command(interaction) do
+      # ...
+
+      # Since `:content` is included, Nosedrum will infer `type: :channel_message_with_source`
+      response = [
+        content: "Hello, world!",
+        ephemeral?: true,
+        allowed_mentions: ["users", "roles"]
+      ]
+
+      {:response, response}
+    end
+
+  """
+  @type response :: [response_field]
+
+  @typedoc """
+  An option (aka an argument) for an application command.
+
+  See `options/0` for examples.
+  """
+  @type option :: %{
+          optional(:required) => true | false,
+          optional(:choices) => [choice],
+          optional(:options) => [option],
+          type:
+            :sub_command
+            | :sub_command_group
+            | :string
+            | :integer
+            | :boolean
+            | :user
+            | :channel
+            | :role
+            | :mentionable
+            | :number,
+          name: String.t(),
+          description: String.t()
+        }
+
+  @typedoc """
+  A choice for an option.
+
+  See `options/0` for examples.
+  """
+  @type choice :: %{
+          name: String.t(),
+          value: String.t() | number()
+        }
+
+  @doc """
+  Returns an atom indicating what kind of application command this module represents.
+  """
+  @callback type() :: :slash | :message | :user
+
+  @doc """
+  Returns a description of the command. Used when registering the command with Discord.
+
+  ## Example
+
+    def description, do: "This is a command description."
+  """
+  @callback description() :: String.t()
+
+  @doc """
+  An optional callback that returns a list of options (aka arguments) that the
+  command takes. Used when registering the command with Discord. Only valid for
+  CHAT_INPUT aka slash commands.
+
+  Read more in the official
+  [Application Command documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
+
+  ## Example
+
+    # For example, the options for a /role command might look like...
+    def options, do:
+      [
+        %{
+          type: :user,
+          name: "user",
+          description: "The user to assign the role to.",
+          required: true # Defaults to false if not specified.
+        },
+        %{
+          type: :role,
+          name: "role",
+          description: "The role to be assigned.",
+          required: true,
+          choices: [
+            %{
+              name: "Event Notifications",
+              value: 123456789123456789 # A role ID, passed to your `command/1` callback via the Interaction struct.
+            },
+            %{
+              name: "Announcements",
+              value: 123456789123456790
+            }
+          ]
+        }
+      ]
+  """
+  @callback options() :: [option]
+
+  @doc """
+  Execute the command invoked by the given `t:Nostrum.Struct.Interaction.t/0`.
+  """
+  @callback command(Interaction.t()) :: response
+
+  @optional_callbacks [options: 0]
+end

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -6,8 +6,12 @@ defmodule Nosedrum.ApplicationCommand do
   Like regular commands, application command modules are stateless on their own.
   """
 
-  @type response_type :: :channel_message_with_source | :deferred_channel_message_with_source |
-  :deferred_update_message | :pong | :update_message
+  @type response_type ::
+          :channel_message_with_source
+          | :deferred_channel_message_with_source
+          | :deferred_update_message
+          | :pong
+          | :update_message
 
   @typedoc """
   `:allowed_mentions` should contain "users", "roles", and/or "everyone", or be an empty list.
@@ -28,20 +32,20 @@ defmodule Nosedrum.ApplicationCommand do
   either `:embeds` or `:content` must be present.
 
   ## Example
+  ```elixir
+  def command(interaction) do
+    # ...
 
-    def command(interaction) do
-      # ...
+    # Since `:content` is included, Nosedrum will infer `type: :channel_message_with_source`
+    response = [
+      content: "Hello, world!",
+      ephemeral?: true,
+      allowed_mentions: ["users", "roles"]
+    ]
 
-      # Since `:content` is included, Nosedrum will infer `type: :channel_message_with_source`
-      response = [
-        content: "Hello, world!",
-        ephemeral?: true,
-        allowed_mentions: ["users", "roles"]
-      ]
-
-      {:response, response}
-    end
-
+    {:response, response}
+  end
+  ```
   """
   @type response :: [response_field]
 
@@ -88,8 +92,9 @@ defmodule Nosedrum.ApplicationCommand do
   Returns a description of the command. Used when registering the command with Discord.
 
   ## Example
-
-    def description, do: "This is a command description."
+  ```elixir
+  def description, do: "This is a command description."
+  ```
   """
   @callback description() :: String.t()
 
@@ -102,33 +107,34 @@ defmodule Nosedrum.ApplicationCommand do
   [Application Command documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
 
   ## Example
-
-    # For example, the options for a /role command might look like...
-    def options, do:
-      [
-        %{
-          type: :user,
-          name: "user",
-          description: "The user to assign the role to.",
-          required: true # Defaults to false if not specified.
-        },
-        %{
-          type: :role,
-          name: "role",
-          description: "The role to be assigned.",
-          required: true,
-          choices: [
-            %{
-              name: "Event Notifications",
-              value: 123456789123456789 # A role ID, passed to your `command/1` callback via the Interaction struct.
-            },
-            %{
-              name: "Announcements",
-              value: 123456789123456790
-            }
-          ]
-        }
-      ]
+  ```elixir
+  # For example, the options for a /role command might look like...
+  def options, do:
+    [
+      %{
+        type: :user,
+        name: "user",
+        description: "The user to assign the role to.",
+        required: true # Defaults to false if not specified.
+      },
+      %{
+        type: :role,
+        name: "role",
+        description: "The role to be assigned.",
+        required: true,
+        choices: [
+          %{
+            name: "Event Notifications",
+            value: 123456789123456789 # A role ID, passed to your `command/1` callback via the Interaction struct.
+          },
+          %{
+            name: "Announcements",
+            value: 123456789123456790
+          }
+        ]
+      }
+    ]
+  ```
   """
   @callback options() :: [option]
 

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -30,9 +30,9 @@ defmodule Nosedrum.Interactor do
   **Note** that Discord only supports nesting 3 levels deep, like `command -> subcommand group -> subcommand`.
   """
   @type application_command_path ::
-    String.t()
+    %{name :: String.t() => app_cmd_module :: module}
     | %{
-      {name :: String.t(), desc :: String.t()} => [application_command_path()]
+      {group_name :: String.t(), group_desc :: String.t()} => application_command_path
     }
 
   @doc """
@@ -47,7 +47,7 @@ defmodule Nosedrum.Interactor do
 
   If the command already exists, it will be overwritten.
   """
-  @callback add_command(path :: application_command_path, scope :: command_scope, command :: Module.t()) ::
+  @callback add_command(path :: application_command_path, scope :: command_scope) ::
               :ok | {:error, String.t()}
 
   @doc """

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -18,7 +18,7 @@ defmodule Nosedrum.Interactor do
     channel_message_with_source: 4,
     deferred_channel_message_with_source: 5,
     deferred_update_message: 6,
-    update_message: 7,
+    update_message: 7
   }
 
   @type command_scope :: :global | Snowflake.t() | [Snowflake.t()]
@@ -30,11 +30,11 @@ defmodule Nosedrum.Interactor do
   **Note** that Discord only supports nesting 3 levels deep, like `command -> subcommand group -> subcommand`.
   """
   @type application_command_path ::
-    %{
-      {group_name :: String.t(), group_desc :: String.t()} => [
-        application_command_path | [Nosedrum.ApplicationCommand.option()]
-      ]
-    }
+          %{
+            {group_name :: String.t(), group_desc :: String.t()} => [
+              application_command_path | [Nosedrum.ApplicationCommand.option()]
+            ]
+          }
 
   @doc """
   Handle an Application Command invocation.
@@ -48,7 +48,11 @@ defmodule Nosedrum.Interactor do
 
   If the command already exists, it will be overwritten.
   """
-  @callback add_command(name_or_path :: String.t() | application_command_path, command_module :: module, scope :: command_scope) ::
+  @callback add_command(
+              name_or_path :: String.t() | application_command_path,
+              command_module :: module,
+              scope :: command_scope
+            ) ::
               :ok | {:error, String.t()}
 
   @doc """
@@ -56,13 +60,18 @@ defmodule Nosedrum.Interactor do
 
   If the command does not exist, no error should be returned.
   """
-  @callback remove_command(name_or_path :: String.t() | application_command_path, scope :: command_scope) ::
+  @callback remove_command(
+              name_or_path :: String.t() | application_command_path,
+              command_id :: Nostrum.Snowflake.t(),
+              scope :: command_scope
+            ) ::
               :ok | {:error, String.t()}
 
   @doc """
   Responds to a given Interaction with `Nosedrum.ApplicationCommand.response` value.
   """
-  @spec respond(Interaction.t(), Nosedrum.ApplicationCommand.response) :: {:ok} | Nostrum.Api.error
+  @spec respond(Interaction.t(), Nosedrum.ApplicationCommand.response()) ::
+          {:ok} | Nostrum.Api.error()
   def respond(interaction, command_response) do
     type =
       command_response
@@ -73,7 +82,7 @@ defmodule Nosedrum.Interactor do
       command_response
       |> Keyword.take([:content, :embeds, :components, :tts?, :allowed_mentions])
       |> Map.new()
-      |> then(&(if command_response[:ephemeral?], do: Map.put(&1, :flags, 64), else: &1))
+      |> then(&if command_response[:ephemeral?], do: Map.put(&1, :flags, 64), else: &1)
 
     res = %{
       type: type,

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -2,16 +2,14 @@ defmodule Nosedrum.Interactor do
   @moduledoc """
   Interactors take the role of both `Nosedrum.Invoker` and `Nosedrum.Storage` when
   it comes to Discord's Application Commands. An Interactor handles incoming
-  `t:Interaction.t/0`s, invoking `Nosedrum.ApplicationCommand.command/1` callbacks
+  `t:Nostrum.Struct.Interaction.t/0`s, invoking `c:Nosedrum.ApplicationCommand.command/1` callbacks
   and responding to the Interaction.
 
   In addition to tracking commands locally for the bot, an Interactor is
-  responsible for registering an Application Command with Discord when `add_command/3`
-  or `remove_command/2` is called.
+  responsible for registering an Application Command with Discord when `c:add_command/4`
+  or `c:remove_command/4` is called.
   """
-
-  alias Nostrum.Snowflake
-  alias Nostrum.Struct.Interaction
+  alias Nostrum.Struct.{Guild, Interaction}
 
   @callback_type_map %{
     pong: 1,
@@ -25,11 +23,11 @@ defmodule Nosedrum.Interactor do
     ephemeral?: 64
   }
 
-  @type command_scope :: :global | Snowflake.t() | [Snowflake.t()]
+  @type command_scope :: :global | Guild.id() | [Guild.id()]
 
   @typedoc """
   Defines a structure of commands, subcommands, subcommand groups, as
-  outlined in the [official documentation](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups)
+  outlined in the [official documentation](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups).
 
   **Note** that Discord only supports nesting 3 levels deep, like `command -> subcommand group -> subcommand`.
 
@@ -102,8 +100,8 @@ defmodule Nosedrum.Interactor do
               :ok | {:error, reason :: String.t()}
 
   @doc """
-  Responds to an Interaction with the values in the given `t:Nosedrum.ApplicationCommand.response()`. Returns `{:ok}` if
-  successful, and a `Nostrum.Api.error()` otherwise.
+  Responds to an Interaction with the values in the given `t:Nosedrum.ApplicationCommand.response/0`. Returns `{:ok}` if
+  successful, and a `t:Nostrum.Api.error/0` otherwise.
   """
   @spec respond(Interaction.t(), Nosedrum.ApplicationCommand.response()) ::
           {:ok} | Nostrum.Api.error()
@@ -132,11 +130,11 @@ defmodule Nosedrum.Interactor do
   end
 
   defp put_flags(data_map, command_response) do
-    Enum.reduce(@flag_map, data_map, fn {flag, value} ->
+    Enum.reduce(@flag_map, data_map, fn {flag, value}, data_map_acc ->
       if command_response[flag] do
-        Map.put(data_map, :flags, value)
+        Map.put(data_map_acc, :flags, value)
       else
-        data_map
+        data_map_acc
       end
     end)
   end

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -36,12 +36,14 @@ defmodule Nosedrum.Interactor do
             ]
           }
 
+  @type name_or_pid :: atom() | pid()
+
   @doc """
   Handle an Application Command invocation.
 
   This callback is responsible
   """
-  @callback handle_interaction(interaction :: Interaction.t()) :: :ok
+  @callback handle_interaction(interaction :: Interaction.t(), name_or_pid) :: :ok
 
   @doc """
   Add a new command under the given `path`.
@@ -51,7 +53,8 @@ defmodule Nosedrum.Interactor do
   @callback add_command(
               name_or_path :: String.t() | application_command_path,
               command_module :: module,
-              scope :: command_scope
+              scope :: command_scope,
+              name_or_pid
             ) ::
               :ok | {:error, String.t()}
 
@@ -63,7 +66,8 @@ defmodule Nosedrum.Interactor do
   @callback remove_command(
               name_or_path :: String.t() | application_command_path,
               command_id :: Nostrum.Snowflake.t(),
-              scope :: command_scope
+              scope :: command_scope,
+              name_or_pid
             ) ::
               :ok | {:error, String.t()}
 

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -21,7 +21,7 @@ defmodule Nosedrum.Interactor do
     update_message: 7,
   }
 
-  @type command_scope :: :global | {:guild, Snowflake.t() | [Snowflake.t()]}
+  @type command_scope :: :global | Snowflake.t() | [Snowflake.t()]
 
   @typedoc """
   Defines a structure of commands, subcommands, subcommand groups, as

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -24,15 +24,16 @@ defmodule Nosedrum.Interactor do
   @type command_scope :: :global | {:guild, Snowflake.t() | [Snowflake.t()]}
 
   @typedoc """
-  Defines either the name of an Application Command, or a structure of commands, subcommands, subcommand groups, as
+  Defines a structure of commands, subcommands, subcommand groups, as
   outlined in the [official documentation](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups)
 
   **Note** that Discord only supports nesting 3 levels deep, like `command -> subcommand group -> subcommand`.
   """
   @type application_command_path ::
-    %{name :: String.t() => app_cmd_module :: module}
-    | %{
-      {group_name :: String.t(), group_desc :: String.t()} => application_command_path
+    %{
+      {group_name :: String.t(), group_desc :: String.t()} => [
+        application_command_path | [Nosedrum.ApplicationCommand.option()]
+      ]
     }
 
   @doc """
@@ -47,7 +48,7 @@ defmodule Nosedrum.Interactor do
 
   If the command already exists, it will be overwritten.
   """
-  @callback add_command(path :: application_command_path, scope :: command_scope) ::
+  @callback add_command(name_or_path :: String.t() | application_command_path, command_module :: module, scope :: command_scope) ::
               :ok | {:error, String.t()}
 
   @doc """
@@ -55,7 +56,7 @@ defmodule Nosedrum.Interactor do
 
   If the command does not exist, no error should be returned.
   """
-  @callback remove_command(path :: application_command_path, scope :: command_scope) ::
+  @callback remove_command(name_or_path :: String.t() | application_command_path, scope :: command_scope) ::
               :ok | {:error, String.t()}
 
   @doc """

--- a/lib/nosedrum/interactor.ex
+++ b/lib/nosedrum/interactor.ex
@@ -1,0 +1,84 @@
+defmodule Nosedrum.Interactor do
+  @moduledoc """
+  Interactors take the role of both `Nosedrum.Invoker` and `Nosedrum.Storage` when
+  it comes to Discord's Application Commands. An Interactor handles incoming
+  `t:Interaction.t/0`s, invoking `Nosedrum.ApplicationCommand.command/1` callbacks
+  and responding to the Interaction.
+
+  In addition to updating commands in its local state, an Interactor is
+  responsible for registering an Application Command with Discord when `add_command/3`
+  or `remove_command/2` is called.
+  """
+
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.Interaction
+
+  @callback_type_map %{
+    pong: 1,
+    channel_message_with_source: 4,
+    deferred_channel_message_with_source: 5,
+    deferred_update_message: 6,
+    update_message: 7,
+  }
+
+  @type command_scope :: :global | {:guild, Snowflake.t() | [Snowflake.t()]}
+
+  @typedoc """
+  Defines either the name of an Application Command, or a structure of commands, subcommands, subcommand groups, as
+  outlined in the [official documentation](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups)
+
+  **Note** that Discord only supports nesting 3 levels deep, like `command -> subcommand group -> subcommand`.
+  """
+  @type application_command_path ::
+    String.t()
+    | %{
+      {name :: String.t(), desc :: String.t()} => [application_command_path()]
+    }
+
+  @doc """
+  Handle an Application Command invocation.
+
+  This callback is responsible
+  """
+  @callback handle_interaction(interaction :: Interaction.t()) :: :ok
+
+  @doc """
+  Add a new command under the given `path`.
+
+  If the command already exists, it will be overwritten.
+  """
+  @callback add_command(path :: application_command_path, scope :: command_scope, command :: Module.t()) ::
+              :ok | {:error, String.t()}
+
+  @doc """
+  Remove the command under the given `path`.
+
+  If the command does not exist, no error should be returned.
+  """
+  @callback remove_command(path :: application_command_path, scope :: command_scope) ::
+              :ok | {:error, String.t()}
+
+  @doc """
+  Responds to a given Interaction with `Nosedrum.ApplicationCommand.response` value.
+  """
+  @spec respond(Interaction.t(), Nosedrum.ApplicationCommand.response) :: {:ok} | Nostrum.Api.error
+  def respond(interaction, command_response) do
+    type =
+      command_response
+      |> Keyword.get(:type, :channel_message_with_source)
+      |> then(&Map.get(@callback_type_map, &1))
+
+    data =
+      command_response
+      |> Keyword.take([:content, :embeds, :components, :tts?, :allowed_mentions])
+      |> Map.new()
+      |> then(&(if command_response[:ephemeral?], do: Map.put(&1, :flags, 64), else: &1))
+
+    res = %{
+      type: type,
+      data: data
+    }
+
+    Nostrum.Api.create_interaction_response(interaction, res)
+  end
+end

--- a/lib/nosedrum/interactor/dispatcher.ex
+++ b/lib/nosedrum/interactor/dispatcher.ex
@@ -6,8 +6,8 @@ defmodule Nosedrum.Interactor.Dispatcher do
 
   use GenServer
 
-  alias Nostrum.Struct.Interaction
   alias Nosedrum.Interactor
+  alias Nostrum.Struct.Interaction
 
   @option_type_map %{
     sub_command: 1,
@@ -32,8 +32,6 @@ defmodule Nosedrum.Interactor.Dispatcher do
     GenServer.cast(id, {:handle, interaction})
   end
 
-  # TODO: Add an `:overwrite?` option to add_command. When false, add_command will do nothing if a command under the
-  # given path is already registered. Default to true
   @impl true
   def add_command(path, command, scope, id \\ __MODULE__) do
     payload = build_payload(path, command)
@@ -202,8 +200,6 @@ defmodule Nosedrum.Interactor.Dispatcher do
     end)
   end
 
-  # TODO: Might want to let the user define a `options/1` callback in their command module, where the parameter is the
-  # tuple key for these options in the path (i.e. {"get", "Get permissions for a user"})
   defp build_payload({options, _command}) when is_list(options) do
     parse_option_types(options)
   end

--- a/lib/nosedrum/interactor/dispatcher.ex
+++ b/lib/nosedrum/interactor/dispatcher.ex
@@ -1,0 +1,141 @@
+defmodule Nosedrum.Interactor.Dispatcher do
+  @moduledoc """
+  An implementation of `Nosedrum.Interactor`, dispatching Application Command Interactions to the appropriate modules.
+  """
+  @behaviour Nosedrum.Interactor
+
+  use GenServer
+
+  alias Nostrum.Struct.Interaction
+  alias Nosedrum.Interactor
+
+  ## Api
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def handle_interaction(%Interaction{} = interaction) do
+    GenServer.cast(__MODULE__, {:handle, interaction})
+  end
+
+  # TODO: Add an `:overwrite?` option to add_command. When false, add_command will do nothing if a command under the
+  # given path is already registered
+  @impl true
+  def add_command(path, scope, command) do
+    payload = build_payload(path, command)
+
+    GenServer.call(__MODULE__, {:add, payload, path, scope, command})
+  end
+
+  defp build_payload(path, command) when is_binary(path) do
+    options = if function_exported?(command, :options, 0) do
+      command.options()
+    else
+      []
+    end
+    IO.inspect command
+    IO.inspect function_exported?(command, :options, 0)
+
+    %{
+      type: parse_type(command.type()),
+      name: path,
+      description: command.description(),
+      options: options,
+    }
+  end
+
+  defp build_payload(path, command) when is_list(path) do
+    Enum.map(path, fn {{name, desc}, list} ->
+      if get_depth(path) == 3 do
+        %{
+          name: name,
+          description: desc,
+          options: build_payload(list, command),
+        }
+      else
+        # Determine type based on depth of the remaining path. 2 is SUB_COMMAND_GROUP and 1 is SUB_COMMAND
+        type = get_depth(list) == 2 && 2 || 1
+
+        %{
+          type: type,
+          name: name,
+          description: desc,
+          options: build_payload(list, command),
+        }
+      end
+    end)
+  end
+
+  @impl true
+  def remove_command(path, scope) do
+
+  end
+
+  ## Impl
+  @impl true
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
+
+  @impl true
+  def handle_call({:add, payload, path, :global, command}, _from, commands) do
+    case Nostrum.Api.create_global_application_command(payload) do
+      {:ok, _} = response ->
+        {:reply, response, Map.put(commands, path, command)}
+      error ->
+        {:reply, {:error, error}, commands}
+    end
+  end
+
+  @impl true
+  def handle_call({:add, payload, path, {:guild, guild_ids}, command}, _from, commands) when is_list(guild_ids) do
+    Enum.each(guild_ids, fn guild_id ->
+      case Nostrum.Api.create_guild_application_command(guild_id, payload) do
+        {:ok, _} = response ->
+          {:reply, response, Map.put(commands, path, command)}
+        error ->
+          {:reply, {:error, error}, commands}
+      end
+    end)
+  end
+
+  @impl true
+  def handle_call({:add, payload, path, {:guild, guild_id}, command}, _from, commands) do
+    case Nostrum.Api.create_guild_application_command(guild_id, payload) do
+      {:ok, _} = response ->
+        {:reply, response, Map.put(commands, path, command)}
+      error ->
+        {:reply, {:error, error}, commands}
+    end
+  end
+
+  @impl true
+  def handle_cast({:handle, %Interaction{data: %{name: name}} = interaction}, commands) do
+    with {:ok, module} <- Map.fetch(commands, name) do
+      response = module.command(interaction)
+      Interactor.respond(interaction, response)
+    end
+    {:noreply, commands}
+  end
+
+  defp parse_type(type) do
+    Map.fetch!(%{
+      slash: 1,
+      user: 2,
+      message: 3,
+    }, type)
+  end
+
+  defp get_depth(path, depth) when is_binary(path) do
+    depth + 1
+  end
+
+  defp get_depth(path, depth) do
+    get_depth(path, depth + 1)
+  end
+
+  defp get_depth(path) do
+    get_depth(path, 0)
+  end
+end

--- a/lib/nosedrum/interactor/dispatcher.ex
+++ b/lib/nosedrum/interactor/dispatcher.ex
@@ -164,9 +164,14 @@ defmodule Nosedrum.Interactor.Dispatcher do
     %{
       type: parse_type(command.type()),
       name: name,
-      description: command.description(),
-      options: options
     }
+    |> then(& if command.type() == :slash do
+      &1
+      |> Map.put(:description, command.description())
+      |> Map.put(:options, options)
+    else
+      &1
+    end)
   end
 
   # This seems like a hacky way to unwrap the outer list...

--- a/lib/nosedrum/interactor/dispatcher.ex
+++ b/lib/nosedrum/interactor/dispatcher.ex
@@ -161,15 +161,17 @@ defmodule Nosedrum.Interactor.Dispatcher do
 
     %{
       type: parse_type(command.type()),
-      name: name,
+      name: name
     }
-    |> then(& if command.type() == :slash do
-      &1
-      |> Map.put(:description, command.description())
-      |> Map.put(:options, options)
-    else
-      &1
-    end)
+    |> then(
+      &if command.type() == :slash do
+        &1
+        |> Map.put(:description, command.description())
+        |> Map.put(:options, options)
+      else
+        &1
+      end
+    )
   end
 
   # This seems like a hacky way to unwrap the outer list...

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,11 @@ defmodule Nosedrum.MixProject do
         Predicates: &(&1[:section] == :predicates)
       ],
       groups_for_modules: [
-        "Application Commands": [Nosedrum.ApplicationCommand, Nosedrum.Interactor, Nosedrum.Interactor.Dispatcher],
+        "Application Commands": [
+          Nosedrum.ApplicationCommand,
+          Nosedrum.Interactor,
+          Nosedrum.Interactor.Dispatcher
+        ],
         Functionality: [Nosedrum.Converters, Nosedrum.Helpers, Nosedrum.Predicates],
         Behaviours: [Nosedrum.Command, Nosedrum.Invoker, Nosedrum.MessageCache, Nosedrum.Storage],
         Implementations: [

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Nosedrum.MixProject do
         Predicates: &(&1[:section] == :predicates)
       ],
       groups_for_modules: [
+        "Application Commands": [Nosedrum.ApplicationCommand, Nosedrum.Interactor, Nosedrum.Interactor.Dispatcher],
         Functionality: [Nosedrum.Converters, Nosedrum.Helpers, Nosedrum.Predicates],
         Behaviours: [Nosedrum.Command, Nosedrum.Invoker, Nosedrum.MessageCache, Nosedrum.Storage],
         Implementations: [


### PR DESCRIPTION
Hi @jchristgit! Sorry for disappearing for a while there - I finally got a decent start on this, I think. There's still work to do before turning this into a full PR (checklist below), but I wanted to keep you posted on progress and also to get any early feedback that you may have on my implementation thus far.

I've added two new behaviours: `Nosedrum.Interactor` defines functionality for both storing application command modules and handling interactions. And `Nosedrum.ApplicationCommand` for Slash/User/Message commands.
`Nosedrum.Interactor.Dispatcher` is an implementation of `Interactor`, which basically the minimum functionality the behaviour specifies (and commands are stored in its state, which could be changed to ETS later if desired).

Btw, I noticed stable Nostrum doesn't rate limit `create_global\guild_application_command` calls - is this something that'll be fixed in an upcoming h\*x r\*lease? Or should we handle rate limiting at the Nosedrum level?

To do before PR:
- [x] Test/confirm support for User and Message Application Commands (only tested with Slash commands thus far)
- [x] Add/expand documentation
- [x] User should be able to pass a custom name/pid to `Dispatcher` functions
- ~~Implement "smart updating" on `Dispatcher.add_command/3` (only re-register a command with discord if changes have been made locally)~~
- ~~Rate limiting?~~
- ~~Add tests for Dispatcher~~

Let me know what you think and/or I should add something to the checklist! :slightly_smiling_face: 