### PR TITLE
Improve deferred interaction flow

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -96,7 +96,7 @@ defmodule Nosedrum.ApplicationCommand do
   alias Nostrum.Struct.{Embed, Interaction}
 
   @typedoc """
-  A function called by `Nosedrum.Storage.followup/2` after deferring an interaction response.
+  Called by `Nosedrum.Storage.followup/2` after deferring an interaction response.
   """
   @type callback :: {fun(), args :: list()} | {module(), fn_name :: atom(), args :: list()}
 

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -97,8 +97,11 @@ defmodule Nosedrum.ApplicationCommand do
 
   @typedoc """
   Called by `Nosedrum.Storage.followup/2` after deferring an interaction response.
+
+  The callback should return a response similar to `c:command/1`, excluding the `:type`, `:tts?`, and `:ephemeral?`
+  options.
   """
-  @type callback :: {fun(), args :: list()} | {module(), fn_name :: atom(), args :: list()}
+  @type callback :: {fun(), args :: list()} | mfa()
 
   @typedoc """
   A value of the `:type` field in a `c:command/1` return value. See
@@ -139,8 +142,6 @@ defmodule Nosedrum.ApplicationCommand do
   If you are deferring an interaction response with `:deferred_channel_message_with_source` or
   `:deferred_update_message`, you should also supply a callback under `:type` in the form of
   `{:deferred_*, callback_tuple}` (See the Deferred Response Example below for more details on `callback_tuple`).
-  The callback should return a response similar to `c:command/1`, excluding the `:type`, `:tts?`, and `:ephemeral?`
-  options.
 
   ## Example
 

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -157,11 +157,12 @@ defmodule Nosedrum.ApplicationCommand do
 
   ## Deferred Response Example
 
-  In order to avoid a potential race condition when deferring, you should supply a callback function that Nosedrum for
-  to call only after the initial response. The callback should take the form of `{anonymous_fn, args}`, or an MFA
-  (Module, Function, Args) tuple, like `{MyCommand, :followup_fn, [interaction, extra_arg]}`
+  In order to avoid a potential race condition when deferring, you should supply a callback function for Nosedrum
+  to call only after the initial response succeeds. The callback should take the form of `{anonymous_fn, args}`, or an
+  MFA (Module, Function, Args) tuple, like `{MyCommand, :followup_fn, [interaction, extra_arg]}`
 
   ```elixir
+  @impl Nosedrum.ApplicationCommand
   def command(interaction) do
     [
       type: {:deferred_channel_message_with_source, {&expensive_calculation/1, [interaction]}}
@@ -171,7 +172,7 @@ defmodule Nosedrum.ApplicationCommand do
   defp expensive_calculation(interaction) do
     # ... do expensive things
     [
-      content: "Hello, world!!"
+      content: "Hello, I've been edited in after the original interaction response"
     ]
   end
   ```

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -101,7 +101,7 @@ defmodule Nosedrum.ApplicationCommand do
   The callback should return a response similar to `c:command/1`, excluding the `:type`, `:tts?`, and `:ephemeral?`
   options.
   """
-  @type callback :: {fun(), args :: list()} | mfa()
+  @type callback :: {(... -> response()), args :: list()} | mfa()
 
   @typedoc """
   A value of the `:type` field in a `c:command/1` return value. See

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -101,8 +101,8 @@ defmodule Nosedrum.ApplicationCommand do
   The callback should return a response similar to `c:command/1`, excluding the `:type`, `:tts?`, and `:ephemeral?`
   options.
   """
-  @type callback :: {(... -> response()), args :: list()} | mfa()
-
+  @type callback ::
+          {(... -> response()), args :: list()} | {module(), fn_name :: atom(), args :: list()}
   @typedoc """
   A value of the `:type` field in a `c:command/1` return value. See
   `t:response/0` for more details.

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -145,8 +145,9 @@ defmodule Nosedrum.Storage do
   end
 
   @doc """
-  Edits an interaction with a follow up response. The response is obtained by running the given
-  function/MFA tuple.
+  Edits an interaction with a follow up response.
+  
+  The response is obtained by running the given function/MFA tuple, see `c:callback/0`.
 
   ## Return value
 

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -146,7 +146,7 @@ defmodule Nosedrum.Storage do
 
   @doc """
   Edits an interaction with a follow up response.
-  
+
   The response is obtained by running the given function/MFA tuple, see `c:callback/0`.
 
   ## Return value

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -33,7 +33,7 @@ defmodule Nosedrum.Storage.Dispatcher do
     with {:ok, module} <- GenServer.call(id, {:fetch, interaction}),
          response <- module.command(interaction),
          {:ok} <- Storage.respond(interaction, response),
-         callback_tuple when is_tuple(callback_tuple) <- Keyword.get(response, :type) do
+         {_defer_type, callback_tuple} <- Keyword.get(response, :type) do
       Storage.followup(interaction, callback_tuple)
     else
       :error ->


### PR DESCRIPTION
This PR fixes a potential race condition when editing a deferred interaction response. The main changes are:

- introduces the `ApplicationCommand.callback()` type
- the user can bundle a callback with their defer `:type` (though I've left the standalone `:defer_*` atoms there, mainly for backwards compatibility/flexibility)
- add `Nosedrum.Storage.followup/2`, and update `Dispatcher` to use it
- updated docs and typespecs as appropriate

Closes #27 

I've forgone the option to pass a `fun/1` callback that is automatically passed the interaction, since I think it's cleaner to define a callback as either a `{fun, args}` or MFA tuple, but I'm happy to add that too if you think it will be a useful addition