### PR TITLE
Added the default_member_permissions parameter to adding application commands

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -270,6 +270,18 @@ defmodule Nosedrum.ApplicationCommand do
   @callback options() :: [option]
 
   @doc """
+    An optional callback that returns a bitset for the required default permissions to run this command.
+
+    Example callback that requires that the user has the permission to ban members to be able to see and execute this command
+
+    ```elixir
+    def default_member_permissions, do:
+      Nostrum.Permission.to_bitset([:ban_members])
+    ```
+  """
+  @callback default_member_permissions() :: integer
+
+  @doc """
   Execute the command invoked by the given `t:Nostrum.Struct.Interaction.t/0`. Returns a `t:response/0`
 
   ## Example
@@ -289,5 +301,5 @@ defmodule Nosedrum.ApplicationCommand do
   """
   @callback command(interaction :: Interaction.t()) :: response
 
-  @optional_callbacks [options: 0]
+  @optional_callbacks [options: 0, default_member_permissions: 0]
 end

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -170,11 +170,17 @@ defmodule Nosedrum.Storage.Dispatcher do
         []
       end
 
-    %{
+    payload = %{
       type: parse_type(command.type()),
       name: name
     }
     |> put_type_specific_fields(command, options)
+
+    if function_exported?(command, :default_member_permissions, 0) do
+      Map.put(payload, :default_member_permissions, command.default_member_permissions())
+    else
+      payload
+    end
   end
 
   # This seems like a hacky way to unwrap the outer list...


### PR DESCRIPTION
Since changing specific application command permissions is impossible with regular bot tokens anyway, at least we can set the default required permissions to run a command on add. 