### PR TITLE
Change from many create_*_application_command requests to a single bulk_overwrite_*_application_commands request

### DIFF
--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -107,11 +107,11 @@ defmodule Nosedrum.Storage do
   Returns `:ok` if successful, and `{:error, reason}` otherwise.
   """
   @callback add_command(
-    name_or_path :: String.t() | application_command_path,
-    command_module :: module,
-    scope :: command_scope,
-    name_or_pid
-  ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
+              name_or_path :: String.t() | application_command_path,
+              command_module :: module,
+              scope :: command_scope,
+              name_or_pid
+            ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
 
   @doc """
   Remove the command under the given name or application command path.
@@ -137,10 +137,10 @@ defmodule Nosedrum.Storage do
   ## Return value
   Returns `:ok` if successful, and `{:error, reason}` otherwise.
   """
-  @callback process_queued_commands(
-    scope :: command_scope,
-    name_or_pid
-  ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
+  @callback process_queue(
+              scope :: command_scope,
+              name_or_pid
+            ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
 
   @doc """
   Responds to an Interaction with the given `t:Nosedrum.ApplicationCommand.response/0`.

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -85,9 +85,10 @@ defmodule Nosedrum.Storage do
               | Nostrum.Api.error()
 
   @doc """
-  Add a new command under the given name or application command path.
+  Queues a new command to be registered under the given name or application command path. Queued commands are
+  added to the internal dispatch storage, and will be registered in bulk upon calling process_queue/1
 
-  If the command already exists, it will be overwritten.
+  If any command already exists, it will be overwritten.
 
   ## Return value
   Returns `:ok` if successful, and `{:error, reason}` otherwise.
@@ -102,6 +103,9 @@ defmodule Nosedrum.Storage do
   Add a new command under the given name or application command path.
 
   If the command already exists, it will be overwritten.
+
+  When adding many commands, it is recommended to use queue_command, and to call process_queue once all
+  commands are queued for registration.
 
   ## Return value
   Returns `:ok` if successful, and `{:error, reason}` otherwise.
@@ -130,7 +134,7 @@ defmodule Nosedrum.Storage do
             ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
 
   @doc """
-  Register all queued commands to discord, making them available for use
+  Register all currently queued commands to discord, making them available for use
 
   Global commands can take up to 1 hour to be made available. Guild commands are available immediately.
 

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -84,6 +84,7 @@ defmodule Nosedrum.Storage do
               | {:error, :unknown_command}
               | Nostrum.Api.error()
 
+
   @doc """
   Add a new command under the given name or application command path.
 
@@ -95,7 +96,6 @@ defmodule Nosedrum.Storage do
   @callback add_command(
               name_or_path :: String.t() | application_command_path,
               command_module :: module,
-              scope :: command_scope,
               name_or_pid
             ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
 
@@ -114,6 +114,20 @@ defmodule Nosedrum.Storage do
               scope :: command_scope,
               name_or_pid
             ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
+
+
+  @doc """
+  Register all queued commands to discord, making them available for use
+
+  Global commands can take up to 1 hour to be made available. Guild commands are available immediately.
+
+  ## Return value
+  Returns `:ok` if successful, and `{:error, reason}` otherwise.
+  """
+  @callback update_discord(
+    scope :: command_scope,
+    name_or_pid
+  ) :: :ok | {:error, Nostrum.Error.ApiError.t()}
 
   @doc """
   Responds to an Interaction with the given `t:Nosedrum.ApplicationCommand.response/0`.

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -49,7 +49,7 @@ defmodule Nosedrum.Storage.Dispatcher do
   end
 
   @impl true
-  def process_queued_commands(scope, id \\ __MODULE__) do
+  def process_queue(scope, id \\ __MODULE__) do
     GenServer.call(id, {:process_queue, scope})
   end
 
@@ -58,7 +58,7 @@ defmodule Nosedrum.Storage.Dispatcher do
     command_name =
       if is_binary(path) do
         path
-      else # Doesn't this prevent any lists being passed to :add, thus making the :add guild_id_list overload redundant?
+      else
         path
         |> Enum.take(1)
         |> List.first()
@@ -97,9 +97,10 @@ defmodule Nosedrum.Storage.Dispatcher do
   end
 
   def handle_call({:process_queue, :global}, _from, commands) do
-    command_list = Enum.map(commands, fn {p, c} ->
-      build_payload(p, c)
-    end)
+    command_list =
+      Enum.map(commands, fn {p, c} ->
+        build_payload(p, c)
+      end)
 
     case Nostrum.Api.bulk_overwrite_global_application_commands(command_list) do
       {:ok, _} = response ->
@@ -111,9 +112,10 @@ defmodule Nosedrum.Storage.Dispatcher do
   end
 
   def handle_call({:process_queue, guild_id}, _from, commands) do
-    command_list = Enum.map(commands, fn {p, c} ->
-      build_payload(p, c)
-    end)
+    command_list =
+      Enum.map(commands, fn {p, c} ->
+        build_payload(p, c)
+      end)
 
     case Nostrum.Api.bulk_overwrite_guild_application_commands(guild_id, command_list) do
       {:ok, _} = response ->

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -32,13 +32,13 @@ defmodule Nosedrum.Storage.Dispatcher do
 
   @impl true
   def handle_call({:build, name, command}, _from, commands) do
-    {:reply, :ok, Map.put(commands, name, command)} |> IO.inspect
+    {:reply, :ok, Map.put(commands, name, command)}
   end
 
   def handle_call({:submit, guild_id}, _from, commands) do
     command_list = Enum.map(commands, fn {p, c} ->
       build_payload(p, c)
-    end) |> IO.inspect
+    end)
 
     case Nostrum.Api.bulk_overwrite_guild_application_commands(guild_id, command_list) do
       {:ok, _} = response ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nosedrum.MixProject do
   def project do
     [
       app: :nosedrum,
-      version: "0.6.0-beta1",
+      version: "0.6.0-rc1",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/jchristgit/nosedrum",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nosedrum.MixProject do
   def project do
     [
       app: :nosedrum,
-      version: "0.6.0-rc1",
+      version: "0.6.0",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/jchristgit/nosedrum",


### PR DESCRIPTION
## Problem
Nosedrum currently makes one request to Nostrum.Api.create_{guild, global}_application_command for each command being "added". This would be fine if Nosedrum's default storage "Dispatcher" had a way of keeping track of commands while the bot is not running (eg. a database or some other external storage). As it stands, if a bot has to restart it loses all links to the Discord commands. While Discord still maintains the existing commands, the only way to re-link them to the command modules is by re-registering them.

## Proposed Solution
Discord (and Nostrum) provide an alternative endpoint to avoid running into rate limits when re-registering commands. By using the bulk_overwrite_*_application_command endpoints we're able to link the existing commands on Discord's side with the modules on our application's side, without running into the 200 per guild daily rate limit applied to the create endpoint.

Essentially it's resorting to a sort of builder pattern. We add all the commands to Nosedrum's command map before calling update_discord/2 which makes a single call to bulk_overwrite_*_application_command.

## This Is A Breaking Change 
The change from add_command actually sending commands to Discord to simply queueing them up until update_discord/2 is called means that any command registration in existing applications needs to be updated to call update_discord/2 once they have added all their commands.

I'm unaware of how other bot developers implement their command registration when using Nosedrum, so it may also be necessary for bots to perform this add/update step on startup.

## Upsides
- I believe re-adding commands on bot startup is a cleaner solution than storing a text file with command and module names on the file system
- This minimizes the requests sent to discord for a new bot who's registering their commands for the first time
- This makes it possible for bots with greater than 200 commands to register their commands initially

## Downsides
- If someone doesn't re-add all commands when calling update_discord/2 they will be deleted, as per [Nostrum](https://hexdocs.pm/nostrum/Nostrum.Api.html#bulk_overwrite_global_application_commands/2) and [Discord](https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands) documentation.
- Bots will need to be updated to adjust to this breaking change
- This is a more complex solution than just storing command names and module names in a file and reading them into the storage on startup