### PR TITLE
Update response types

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -117,6 +117,8 @@ defmodule Nosedrum.ApplicationCommand do
           | :update_message
           | :modal
           | :premium_required
+          | integer()
+          | {integer(), callback()}
 
   @typedoc """
   A field in a keyword list interaction response.

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -115,6 +115,8 @@ defmodule Nosedrum.ApplicationCommand do
           | {:deferred_update_message, callback()}
           | :pong
           | :update_message
+          | :modal
+          | :premium_required
 
   @typedoc """
   A field in a keyword list interaction response.

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -17,7 +17,9 @@ defmodule Nosedrum.Storage do
     channel_message_with_source: 4,
     deferred_channel_message_with_source: 5,
     deferred_update_message: 6,
-    update_message: 7
+    update_message: 7,
+    modal: 9,
+    premium_required: 10
   }
 
   @flag_map %{

--- a/lib/nosedrum/storage.ex
+++ b/lib/nosedrum/storage.ex
@@ -177,7 +177,11 @@ defmodule Nosedrum.Storage do
     convert_callback_type(type)
   end
 
-  defp convert_callback_type(type) do
+  defp convert_callback_type(type) when is_integer(type) do
+    type
+  end
+
+  defp convert_callback_type(type) when is_atom(type) do
     Map.get(@callback_type_map, type)
   end
 

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -40,7 +40,7 @@ defmodule Nosedrum.Storage.Dispatcher do
         {:error, :unknown_command}
 
       # the response type was not a callback tuple, no need to follow up
-      res_type when is_atom(res_type) ->
+      res_type when is_atom(res_type) or is_integer(res_type) ->
         {:ok}
 
       {:error, reason} ->


### PR DESCRIPTION
This PR adds support for the new response types `:modal` and `:premium_required`. It also allows you to supply an integer instead of an atom. This way you don't have to wait for an update of this library to use a new response type