### PR TITLE
Allow making updates to the command payload, before sending it

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -289,5 +289,13 @@ defmodule Nosedrum.ApplicationCommand do
   """
   @callback command(interaction :: Interaction.t()) :: response
 
+  @doc """
+  Make adjustments to the payload before creating the command with
+  `Nostrum.Api.create_global_application_command/2` or
+  `Nostrum.Api.create_guild_application_command/3`
+  """
+
+  @callback update_command_payload(map) :: map
+
   @optional_callbacks [options: 0]
 end

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -230,6 +230,7 @@ defmodule Nosedrum.Storage.Dispatcher do
       name: name
     }
     |> put_type_specific_fields(command, options)
+    |> apply_payload_updates(command)
   end
 
   # This seems like a hacky way to unwrap the outer list...
@@ -290,6 +291,14 @@ defmodule Nosedrum.Storage.Dispatcher do
       map ->
         map
     end)
+  end
+
+  defp apply_payload_updates(payload, command) do
+    if function_exported?(command, :update_command_payload, 1) do
+      command.update_command_payload(payload)
+    else
+      payload
+    end
   end
 
   defp get_depth(path, depth) do


### PR DESCRIPTION
Wanted to make use of the option `integration_types` but saw that it wasn't possible as of now. For now I want to add this callback, to future-proof the application command creation