### PR TITLE
Fix bug in registering guild-specific commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,9 @@ nosedrum-*.tar
 # Visual Studio Code project files
 .vscode/
 
+# JetBrains files
+.idea
+*.iml
+
 # macOS iCloud sync toggle to prevent filesystem bugs
 /.nosync

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -119,7 +119,7 @@ defmodule Nosedrum.Storage.Dispatcher do
         build_payload(p, c)
       end)
 
-    case ApplicationCommand.bulk_overwrite_global_commands(guild_id, command_list) do
+    case ApplicationCommand.bulk_overwrite_guild_commands(guild_id, command_list) do
       {:ok, _} = response ->
         {:reply, response, commands}
 


### PR DESCRIPTION
It looks like there was a typo in `Nosedrum.Storage.Dispatcher.process_queue/2` such that it was treating both global and guild-specific scopes the same – by calling the function to register a command globally (`Nostrum.Api.ApplicationCommand.bulk_overwrite_global_commands`). When the 2-arity version of this function is called here, it overrides the application id with the guild id and results in a `10002` error from discord. 

The fix was simple; call the correct function instead: `Nostrum.Api.ApplicationCommand.bulk_overwrite_guild_commands`

There don't seem to be any tests for this code yet, but I tested the change in a personal project, and the fix applied here works. 