### PR TITLE
Fixed minor docs typo in Nosedrum.ComponentInteraction

### DIFF
--- a/lib/nosedrum/component_interaction.ex
+++ b/lib/nosedrum/component_interaction.ex
@@ -10,7 +10,7 @@ defmodule Nosedrum.ComponentInteraction do
   @doc """
   Handle message component interactions.
 
-  Behaves the same way as the `Nosedrum.ApplicationCommand.commmand/1` callback.
+  Behaves the same way as the `Nosedrum.ApplicationCommand.command/1` callback.
   """
   @callback message_component_interaction(
               interaction :: Nostrum.Struct.Interaction.t(),


### PR DESCRIPTION
I found a typo while working on another PR regarding the `command` callback in `Nosedrum.ComponentInteraction`. I fixed it! :)