### PR TITLE
Add autocomplete callback support

### DIFF
--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -374,7 +374,9 @@ defmodule Nosedrum.ApplicationCommand do
   It should return a response with `type: :application_command_autocomplete_result`
   and a list of choices.
 
-  If not implemented, the dispatcher will fall back to `c:command/1`.
+  If not implemented, the dispatcher responds to Discord with an empty list of
+  choices and logs a warning. Implement this callback for any command that
+  marks options with `autocomplete: true`.
 
   ## Example
   ```elixir

--- a/lib/nosedrum/application_command.ex
+++ b/lib/nosedrum/application_command.ex
@@ -367,6 +367,32 @@ defmodule Nosedrum.ApplicationCommand do
   @callback command(interaction :: Interaction.t()) :: response
 
   @doc """
+  Handle an autocomplete interaction for this command.
+
+  This callback is invoked when Discord sends an autocomplete interaction
+  (interaction type 4) for a command option with `autocomplete: true`.
+  It should return a response with `type: :application_command_autocomplete_result`
+  and a list of choices.
+
+  If not implemented, the dispatcher will fall back to `c:command/1`.
+
+  ## Example
+  ```elixir
+  @impl true
+  def autocomplete(interaction) do
+    focused = Enum.find(interaction.data.options, & &1.focused)
+    suggestions = MyApp.search(focused.value)
+
+    [
+      type: :application_command_autocomplete_result,
+      choices: Enum.map(suggestions, &%{name: &1, value: &1})
+    ]
+  end
+  ```
+  """
+  @callback autocomplete(interaction :: Interaction.t()) :: response
+
+  @doc """
   Make adjustments to the payload before creating the command with
   `Nostrum.Api.ApplicationCommand.create_global_command/2` or
   `Nostrum.Api.ApplicationCommand.create_guild_command/3`
@@ -375,6 +401,7 @@ defmodule Nosedrum.ApplicationCommand do
 
   @optional_callbacks [
     options: 0,
+    autocomplete: 1,
     default_member_permissions: 0,
     nsfw: 0,
     contexts: 0,

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -61,14 +61,18 @@ defmodule Nosedrum.Storage.Dispatcher do
   # Autocomplete interaction (type 4)
   def handle_interaction(%Interaction{type: 4} = interaction, id) do
     with {:ok, module} <- GenServer.call(id, {:fetch, interaction}) do
-      response =
-        if function_exported?(module, :autocomplete, 1) do
-          module.autocomplete(interaction)
-        else
-          module.command(interaction)
-        end
+      if function_exported?(module, :autocomplete, 1) do
+        Storage.respond(interaction, module.autocomplete(interaction))
+      else
+        Logger.warning(
+          "Received autocomplete interaction for #{inspect(module)} but no autocomplete/1 callback is implemented. Responding with empty choices."
+        )
 
-      Storage.respond(interaction, response)
+        Storage.respond(interaction,
+          type: :application_command_autocomplete_result,
+          choices: []
+        )
+      end
     else
       :error -> {:error, :unknown_command}
       {:error, reason} -> {:error, reason}

--- a/lib/nosedrum/storage/dispatcher.ex
+++ b/lib/nosedrum/storage/dispatcher.ex
@@ -56,7 +56,27 @@ defmodule Nosedrum.Storage.Dispatcher do
   end
 
   @impl true
-  def handle_interaction(%Interaction{} = interaction, id \\ __MODULE__) do
+  def handle_interaction(interaction, id \\ __MODULE__)
+
+  # Autocomplete interaction (type 4)
+  def handle_interaction(%Interaction{type: 4} = interaction, id) do
+    with {:ok, module} <- GenServer.call(id, {:fetch, interaction}) do
+      response =
+        if function_exported?(module, :autocomplete, 1) do
+          module.autocomplete(interaction)
+        else
+          module.command(interaction)
+        end
+
+      Storage.respond(interaction, response)
+    else
+      :error -> {:error, :unknown_command}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Application command and other interactions
+  def handle_interaction(%Interaction{} = interaction, id) do
     with {:ok, module} <- GenServer.call(id, {:fetch, interaction}),
          response <- module.command(interaction),
          :ok <- Storage.respond(interaction, response),


### PR DESCRIPTION
## Summary
Add an optional `autocomplete/1` callback to the `Nosedrum.ApplicationCommand` behaviour, enabling command modules to handle autocomplete interactions separately from regular command invocations.

## Motivation
Discord sends autocomplete interactions (type 4) when a user is typing in an option with `autocomplete: true`. Currently, nosedrum routes these to the same `command/1` callback as regular command invocations, forcing command modules to manually inspect the interaction type and branch accordingly.

This is a pain point for anyone using autocomplete — the command logic and autocomplete logic serve different purposes and should be separate callbacks.

## Changes
- `lib/nosedrum/application_command.ex` — add `autocomplete/1` as an optional callback with documentation and example
- `lib/nosedrum/storage/dispatcher.ex` — split `handle_interaction` so autocomplete interactions (type 4) are routed to `autocomplete/1`. If a command receives an autocomplete interaction but doesn't implement the callback, the dispatcher responds with an empty choices list and logs a warning instead of calling `command/1` (which expects a different payload shape and response type).

## Usage
```elixir
defmodule MyApp.Commands.Search do
  @behaviour Nosedrum.ApplicationCommand

  @impl true
  def type, do: :slash

  @impl true
  def description, do: "Search for something"

  @impl true
  def options do
    [%{type: :string, name: "query", description: "Search query", required: true, autocomplete: true}]
  end

  @impl true
  def autocomplete(interaction) do
    focused = Enum.find(interaction.data.options, & &1.focused)
    results = MyApp.search(focused.value)
    [type: :application_command_autocomplete_result, choices: Enum.map(results, &%{name: &1, value: &1})]
  end

  @impl true
  def command(interaction) do
    [%{name: "query", value: query}] = interaction.data.options
    [content: "Results for: #{query}"]
  end
end
```

## Backwards Compatibility
`autocomplete/1` is an optional callback, so existing command modules don't need any changes to compile. Commands that don't use autocomplete options are unaffected. The only behavioral change is that commands which set `autocomplete: true` on an option must now implement `autocomplete/1` — previously such interactions would silently hit `command/1`, which was incorrect (different response type and payload shape).

## Testing
- `mix compile --warnings-as-errors` passes
- `mix test --no-start` — 79 tests, 0 failures
